### PR TITLE
Make launch file equivilant to ROS1

### DIFF
--- a/cloudwatch_logger/launch/cloudwatch_logger.launch.py
+++ b/cloudwatch_logger/launch/cloudwatch_logger.launch.py
@@ -14,20 +14,50 @@
 """Launch a lifecycle cloudwatch_logger node"""
 
 import os
+import yaml
 
+import launch
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
-    parameters_file_path = os.path.join(
-        get_package_share_directory('cloudwatch_logger'), 'config', 'sample_configuration.yaml')
+    default_config = os.path.join(get_package_share_directory('cloudwatch_logger'), 'config', 'sample_configuration.yaml')
+    with open(default_config, 'r') as f:
+        config_text = f.read()
+    config_yaml = yaml.safe_load(config_text)
+    default_log_group_name = config_yaml['cloudwatch_logger']['ros__parameters']['log_group_name']
+    default_aws_region = config_yaml['cloudwatch_logger']['ros__parameters']['aws_client_configuration']['region']
+
+    parameters = [launch.substitutions.LaunchConfiguration("config_file")]
+    parameters.append({"log_group_name": launch.substitutions.LaunchConfiguration("log_group_name")})
+    parameters.append({"aws_client_configuration": { "region": launch.substitutions.LaunchConfiguration("aws_region") }})
+  
     return LaunchDescription([
-        Node(package='cloudwatch_logger',
-             node_executable='cloudwatch_logger',
-             parameters=[parameters_file_path],
-             # workaround until https://github.com/ros2/rmw_fastrtps/issues/265 is resolved
-             arguments=["__log_disable_rosout:=true"],
-             output='screen'),
-])
+        launch.actions.DeclareLaunchArgument(
+            "node_name",
+            default_value="cloudwatch_logger",
+        ),
+        launch.actions.DeclareLaunchArgument(
+            "config_file",
+            default_value=default_config
+        ),
+        launch.actions.DeclareLaunchArgument(
+            "aws_region",
+            default_value=default_aws_region
+        ),
+        launch.actions.DeclareLaunchArgument(
+            "log_group_name",
+            default_value=default_log_group_name
+        ),
+        Node(
+            package='cloudwatch_logger',
+            node_executable='cloudwatch_logger',
+            node_name=launch.substitutions.LaunchConfiguration('node_name'),
+            parameters=parameters,
+            # workaround until https://github.com/ros2/rmw_fastrtps/issues/265 is resolved
+            arguments=["__log_disable_rosout:=true"],
+            output='screen'
+        ),
+    ])


### PR DESCRIPTION
- Allow overwriting log_group_name, node_name and aws_region which
default to values in the config file if unspecified.
- Allow overwriting config file path.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
