### PR TITLE
Fix linting issues found by clang-tidy 6.0

### DIFF
--- a/cloudwatch_logger/include/cloudwatch_logger/log_node.h
+++ b/cloudwatch_logger/include/cloudwatch_logger/log_node.h
@@ -41,11 +41,13 @@ public:
    * @param ignore_nodes The set of node names to ignore logs from
    */
   explicit LogNode(int8_t min_log_severity, std::unordered_set<std::string> ignore_nodes);
+  LogNode(const LogNode & other) = delete;
+  LogNode & operator=(const LogNode & other) = delete;
 
   /**
    *  @brief Tears down a AWSCloudWatchLogNode object
    */
-  ~LogNode();
+  ~LogNode() override;
 
   /**
    * @brief Reads creds, region, and SDK option to configure log manager
@@ -59,7 +61,7 @@ public:
   void Initialize(const std::string & log_group, const std::string & log_stream,
                   const Aws::Client::ClientConfiguration & config, Aws::SDKOptions & sdk_options,
                   const Aws::CloudWatchLogs::CloudWatchOptions & cloudwatch_options,
-                  std::shared_ptr<LogServiceFactory> log_service_factory = std::make_shared<LogServiceFactory>());
+                  const std::shared_ptr<LogServiceFactory>& log_service_factory = std::make_shared<LogServiceFactory>());
 
   bool start() override;
   bool shutdown() override;
@@ -69,7 +71,7 @@ public:
    *
    * @param log_msg A log message from the subscribed topic(s)
    */
-  void RecordLogs(const rcl_interfaces::msg::Log::SharedPtr log_msg);
+  void RecordLogs(const rcl_interfaces::msg::Log::SharedPtr& log_msg);
 
   /**
    * @brief Trigger the log manager to call its Service function to publish logs to cloudwatch
@@ -90,7 +92,7 @@ public:
 
 private:
   bool ShouldSendToCloudWatchLogs(const int8_t log_severity_level);
-  const std::string FormatLogs(const rcl_interfaces::msg::Log::SharedPtr log_msg);
+  const std::string FormatLogs(const rcl_interfaces::msg::Log::SharedPtr& log_msg);
   std::shared_ptr<Aws::CloudWatchLogs::LogService> log_service_;
   int8_t min_log_severity_;
   std::unordered_set<std::string> ignore_nodes_;

--- a/cloudwatch_logger/include/cloudwatch_logger/log_node_param_helper.h
+++ b/cloudwatch_logger/include/cloudwatch_logger/log_node_param_helper.h
@@ -66,7 +66,7 @@ constexpr bool kNodeSubscribeToRosoutDefaultValue = true;
  * as returned by \p parameter_reader
  */
 Aws::AwsError ReadPublishFrequency(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   double & publish_frequency);
 
 /**
@@ -77,7 +77,7 @@ Aws::AwsError ReadPublishFrequency(
  * @return an error code that indicates whether the parameter was read successfully or not, 
  * as returned by \p parameter_reader
  */
-Aws::AwsError ReadLogGroup(std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+Aws::AwsError ReadLogGroup(const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
                            std::string & log_group);
 
 /**
@@ -88,7 +88,7 @@ Aws::AwsError ReadLogGroup(std::shared_ptr<Aws::Client::ParameterReaderInterface
  * @return an error code that indicates whether the parameter was read successfully or not, 
  * as returned by \p parameter_reader
  */
-Aws::AwsError ReadLogStream(std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+Aws::AwsError ReadLogStream(const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
                             std::string & log_stream);
 
 /**
@@ -100,7 +100,7 @@ Aws::AwsError ReadLogStream(std::shared_ptr<Aws::Client::ParameterReaderInterfac
  * as returned by \p parameter_reader
  */
 Aws::AwsError ReadSubscribeToRosout(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   bool & subscribe_to_rosout);
 
 /**
@@ -113,7 +113,7 @@ Aws::AwsError ReadSubscribeToRosout(
  * as returned by \p parameter_reader
  */
 Aws::AwsError ReadMinLogVerbosity(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   int8_t & min_log_verbosity);
 
 /**
@@ -130,9 +130,9 @@ Aws::AwsError ReadMinLogVerbosity(
  */
 Aws::AwsError ReadSubscriberList(
   bool subscribe_to_rosout,
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   std::function<void(const rcl_interfaces::msg::Log::SharedPtr)> callback,
-  rclcpp::Node::SharedPtr nh,
+  const rclcpp::Node::SharedPtr& nh,
   std::vector<rclcpp::Subscription<rcl_interfaces::msg::Log>::SharedPtr> & subscriptions);
   
 /**
@@ -144,7 +144,7 @@ Aws::AwsError ReadSubscriberList(
  * as returned by \p parameter_reader
  */
 Aws::AwsError ReadIgnoreNodesSet(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   std::unordered_set<std::string> & ignore_nodes);
 
 /**
@@ -156,7 +156,7 @@ Aws::AwsError ReadIgnoreNodesSet(
  * as returned by \p parameter_reader
  */
 void ReadCloudWatchOptions(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   Aws::CloudWatchLogs::CloudWatchOptions & cloudwatch_options);
 
 /**
@@ -168,7 +168,7 @@ void ReadCloudWatchOptions(
  * as returned by \p parameter_reader
  */
 void ReadUploaderOptions(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   Aws::DataFlow::UploaderOptions & uploader_options);
 
 /**
@@ -180,7 +180,7 @@ void ReadUploaderOptions(
  * as returned by \p parameter_reader
  */
 void ReadFileManagerStrategyOptions(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   Aws::FileManagement::FileManagerStrategyOptions & file_manager_strategy_options);
 
 /**
@@ -194,7 +194,7 @@ void ReadFileManagerStrategyOptions(
  * as returned by \p parameter_reader
  */
 void ReadOption(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   const std::string & option_key,
   const std::string & default_value,
   std::string & option_value);
@@ -210,7 +210,7 @@ void ReadOption(
  * as returned by \p parameter_reader
  */
 void ReadOption(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   const std::string & option_key,
   const size_t & default_value,
   size_t & option_value);

--- a/cloudwatch_logger/src/log_node.cpp
+++ b/cloudwatch_logger/src/log_node.cpp
@@ -39,7 +39,7 @@ LogNode::~LogNode() { this->log_service_ = nullptr; }
 void LogNode::Initialize(const std::string & log_group, const std::string & log_stream,
                          const Aws::Client::ClientConfiguration & config, Aws::SDKOptions & sdk_options,
                          const Aws::CloudWatchLogs::CloudWatchOptions & cloudwatch_options,
-                         std::shared_ptr<LogServiceFactory> factory)
+                         const std::shared_ptr<LogServiceFactory>& factory)
 {
   this->log_service_ = factory->CreateLogService(log_group, log_stream, config, sdk_options, cloudwatch_options);
 }
@@ -79,7 +79,7 @@ bool LogNode::shutdown()
   return is_shutdown;
 }
 
-void LogNode::RecordLogs(const rcl_interfaces::msg::Log::SharedPtr log_msg)
+void LogNode::RecordLogs(const rcl_interfaces::msg::Log::SharedPtr& log_msg)
 {
   if (0 == this->ignore_nodes_.count(log_msg->name)) {
     if (nullptr == this->log_service_) {
@@ -104,7 +104,7 @@ bool LogNode::ShouldSendToCloudWatchLogs(const int8_t log_severity_level)
   return log_severity_level >= this->min_log_severity_;
 }
 
-const std::string LogNode::FormatLogs(const rcl_interfaces::msg::Log::SharedPtr log_msg)
+const std::string LogNode::FormatLogs(const rcl_interfaces::msg::Log::SharedPtr& log_msg)
 {
   std::stringstream ss;
   ss << std::chrono::duration_cast<std::chrono::duration<double>>(

--- a/cloudwatch_logger/src/log_node.cpp
+++ b/cloudwatch_logger/src/log_node.cpp
@@ -25,7 +25,10 @@
 #include <cloudwatch_logs_common/log_service.h>
 #include <rclcpp/rclcpp.hpp>
 
-using namespace Aws::CloudWatchLogs::Utils;
+
+namespace Aws {
+namespace CloudWatchLogs {
+namespace Utils {
 
 LogNode::LogNode(int8_t min_log_severity, std::unordered_set<std::string> ignore_nodes)
   : ignore_nodes_(std::move(ignore_nodes))
@@ -137,3 +140,7 @@ const std::string LogNode::FormatLogs(const rcl_interfaces::msg::Log::SharedPtr&
 
   return ss.str();
 }
+
+}  // namespace Utils
+}  // namespace CloudWatchLogs
+}  // namespace Aws

--- a/cloudwatch_logger/src/log_node_param_helper.cpp
+++ b/cloudwatch_logger/src/log_node_param_helper.cpp
@@ -18,8 +18,7 @@
 #include <aws/core/utils/logging/LogMacros.h>
 #include <cloudwatch_logs_common/cloudwatch_options.h>
 
-
-using namespace Aws::Client;
+using Aws::Client::ParameterPath;
 
 namespace Aws {
 namespace CloudWatchLogs {

--- a/cloudwatch_logger/src/log_node_param_helper.cpp
+++ b/cloudwatch_logger/src/log_node_param_helper.cpp
@@ -26,7 +26,7 @@ namespace CloudWatchLogs {
 namespace Utils {
 
 Aws::AwsError ReadPublishFrequency(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   double & publish_frequency)
 {
   Aws::AwsError ret =
@@ -51,7 +51,7 @@ Aws::AwsError ReadPublishFrequency(
   return ret;
 }
 
-Aws::AwsError ReadLogGroup(std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+Aws::AwsError ReadLogGroup(const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
                            std::string & log_group)
 {
   Aws::AwsError ret = parameter_reader->ReadParam(ParameterPath(kNodeParamLogGroupNameKey), log_group);
@@ -74,7 +74,7 @@ Aws::AwsError ReadLogGroup(std::shared_ptr<Aws::Client::ParameterReaderInterface
   return ret;
 }
 
-Aws::AwsError ReadLogStream(std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+Aws::AwsError ReadLogStream(const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
                             std::string & log_stream)
 {
   Aws::AwsError ret = parameter_reader->ReadParam(ParameterPath(kNodeParamLogStreamNameKey), log_stream);
@@ -98,7 +98,7 @@ Aws::AwsError ReadLogStream(std::shared_ptr<Aws::Client::ParameterReaderInterfac
 }
 
 Aws::AwsError ReadSubscribeToRosout(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   bool & subscribe_to_rosout)
 {
   Aws::AwsError ret =
@@ -127,7 +127,7 @@ Aws::AwsError ReadSubscribeToRosout(
 }
 
 Aws::AwsError ReadMinLogVerbosity(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   int8_t & min_log_verbosity)
 {
   min_log_verbosity = kNodeMinLogVerbosityDefaultValue;
@@ -173,9 +173,9 @@ Aws::AwsError ReadMinLogVerbosity(
 
 Aws::AwsError ReadSubscriberList(
   const bool subscribe_to_rosout,
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   std::function<void(const rcl_interfaces::msg::Log::SharedPtr)> callback,
-  rclcpp::Node::SharedPtr nh,
+  const rclcpp::Node::SharedPtr& nh,
   std::vector<rclcpp::Subscription<rcl_interfaces::msg::Log>::SharedPtr> & subscriptions)
 {
   std::vector<std::string> topics;
@@ -197,7 +197,7 @@ Aws::AwsError ReadSubscriberList(
 }
 
 Aws::AwsError ReadIgnoreNodesSet(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   std::unordered_set<std::string> & ignore_nodes)
 {
   std::vector<std::string> ignore_list;
@@ -219,11 +219,11 @@ Aws::AwsError ReadIgnoreNodesSet(
 }
 
 void ReadCloudWatchOptions(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   Aws::CloudWatchLogs::CloudWatchOptions & cloudwatch_options)
 {
 
-  Aws::DataFlow::UploaderOptions uploader_options;
+  Aws::DataFlow::UploaderOptions uploader_options{};
   Aws::FileManagement::FileManagerStrategyOptions file_manager_strategy_options;
 
   ReadUploaderOptions(parameter_reader, uploader_options);
@@ -236,7 +236,7 @@ void ReadCloudWatchOptions(
 }
 
 void ReadUploaderOptions(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   Aws::DataFlow::UploaderOptions & uploader_options)
 {
 
@@ -277,7 +277,7 @@ void ReadUploaderOptions(
 }
 
 void ReadFileManagerStrategyOptions(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   Aws::FileManagement::FileManagerStrategyOptions & file_manager_strategy_options)
 {
 
@@ -313,7 +313,7 @@ void ReadFileManagerStrategyOptions(
 }
 
 void ReadOption(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   const std::string & option_key,
   const std::string & default_value,
   std::string & option_value)
@@ -336,7 +336,7 @@ void ReadOption(
 }
 
 void ReadOption(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   const std::string & option_key,
   const size_t & default_value,
   size_t & option_value)
@@ -350,7 +350,7 @@ void ReadOption(
                          option_key << " parameter not found, setting to default value: " << default_value);
       break;
     case Aws::AwsError::AWS_ERR_OK:
-      option_value = (size_t)return_value;
+      option_value = static_cast<size_t>(return_value);
       AWS_LOGSTREAM_INFO(__func__, option_key << " is set to: " << option_value);
       break;
     default:

--- a/cloudwatch_logger/src/main.cpp
+++ b/cloudwatch_logger/src/main.cpp
@@ -24,7 +24,6 @@
 
 #include <cloudwatch_logs_common/cloudwatch_options.h>
 
-using namespace Aws::CloudWatchLogs::Utils;
 
 constexpr char kNodeName[] = "cloudwatch_logger";
 
@@ -59,14 +58,14 @@ int main(int argc, char ** argv)
     std::make_shared<Aws::Client::Ros2NodeParameterReader>(nh);
 
   // checking configurations to set values or set to default values;
-  ReadPublishFrequency(parameter_reader, publish_frequency);
-  ReadLogGroup(parameter_reader, log_group);
-  ReadLogStream(parameter_reader, log_stream);
-  ReadSubscribeToRosout(parameter_reader, subscribe_to_rosout);
-  ReadMinLogVerbosity(parameter_reader, min_log_verbosity);
-  ReadIgnoreNodesSet(parameter_reader, ignore_nodes);
+  Aws::CloudWatchLogs::Utils::ReadPublishFrequency(parameter_reader, publish_frequency);
+  Aws::CloudWatchLogs::Utils::ReadLogGroup(parameter_reader, log_group);
+  Aws::CloudWatchLogs::Utils::ReadLogStream(parameter_reader, log_stream);
+  Aws::CloudWatchLogs::Utils::ReadSubscribeToRosout(parameter_reader, subscribe_to_rosout);
+  Aws::CloudWatchLogs::Utils::ReadMinLogVerbosity(parameter_reader, min_log_verbosity);
+  Aws::CloudWatchLogs::Utils::ReadIgnoreNodesSet(parameter_reader, ignore_nodes);
 
-  ReadCloudWatchOptions(parameter_reader, cloudwatch_options);
+  Aws::CloudWatchLogs::Utils::ReadCloudWatchOptions(parameter_reader, cloudwatch_options);
 
   // configure aws settings
   Aws::Client::ClientConfigurationProvider client_config_provider(parameter_reader);
@@ -97,7 +96,7 @@ int main(int argc, char ** argv)
   };
 
   // subscribe to additional topics, if any
-  ReadSubscriberList(subscribe_to_rosout, parameter_reader, callback, nh, subscriptions);
+  Aws::CloudWatchLogs::Utils::ReadSubscriberList(subscribe_to_rosout, parameter_reader, callback, nh, subscriptions);
   AWS_LOGSTREAM_INFO(__func__, "Initialized " << kNodeName << ".");
 
   bool publish_when_size_reached = cloudwatch_options.uploader_options.batch_trigger_publish_size

--- a/cloudwatch_logger/test/log_node_param_helper_test.cpp
+++ b/cloudwatch_logger/test/log_node_param_helper_test.cpp
@@ -21,7 +21,6 @@
 
 using namespace Aws::Client;
 using namespace Aws::CloudWatchLogs::Utils;
-using ::testing::_;
 using ::testing::Eq;
 using ::testing::A;
 using ::testing::InSequence;

--- a/cloudwatch_logger/test/log_node_test.cpp
+++ b/cloudwatch_logger/test/log_node_test.cpp
@@ -22,9 +22,11 @@
 #include <cloudwatch_logs_common/log_publisher.h>
 #include <cloudwatch_logs_common/log_service_factory.h>
 #include <rcl_interfaces/msg/log.hpp>
+#include <utility>
 
 using namespace Aws::CloudWatchLogs;
 using namespace Aws::CloudWatchLogs::Utils;
+using namespace Aws::FileManagement;
 using ::testing::_;
 using ::testing::AllOf;
 using ::testing::HasSubstr;
@@ -69,7 +71,7 @@ public:
   LogServiceMock(std::shared_ptr<Publisher<LogCollection>> log_publisher,
                  std::shared_ptr<DataBatcher<LogType>> log_batcher,
                  std::shared_ptr<FileUploadStreamer<LogCollection>> log_file_upload_streamer = nullptr)
-    : LogService(log_publisher, log_batcher, log_file_upload_streamer) {}
+    : LogService(std::move(log_publisher), std::move(log_batcher), std::move(log_file_upload_streamer)) {}
 
   MOCK_METHOD1(batchData, bool(const std::string & data_to_batch));
   MOCK_METHOD0(start, bool());


### PR DESCRIPTION
*Description of changes:*

Fixing linting issues found by `clang-tidy` 6.0, without introducing public API changes (there may be ABI changes though).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.