### PR TITLE
Add option for FileManagerStrategy delete stale data

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ An example configuration file called `sample_configuration.yaml` is provided. Wh
 | min_log_verbosity| The minimum log severity for sending logs selectively to AWS CloudWatch Logs, log messages with a severity lower than `min_log_verbosity` will be ignored | *std::string* | DEBUG/INFO/WARN/ERROR/FATAL | DEBUG |
 | storage_directory | The location where all offline metrics will be stored | *string* | string | ~/.ros/cwlogs/ |
 | storage_limit | The maximum size of all offline storage files in KB. Once this limit is reached offline logs will start to be deleted oldest first. | *int* | number | 1048576 |
+| delete_stale_data | Whether or not to delete log batch data that are over 14 days old, which are rejected by [AWS PutLogEvents](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html). | *bool* | true/false | false |
 | aws_client_configuration | AWS region configuration | *std::string* | *region*: "us-west-2"/"us-east-1"/"us-east-2"/etc. | region: us-west-2 |
 
 ### Advanced Configuration Parameters

--- a/cloudwatch_logger/config/sample_configuration.yaml
+++ b/cloudwatch_logger/config/sample_configuration.yaml
@@ -42,6 +42,10 @@ cloudwatch_logger:
     # The maximum size of all files in offline storage in KB
     storage_limit: 1048576
 
+    # whether or not to automatically delete log data > 14 days old
+    #default value is: false
+    delete_stale_data: false
+
     # This is the AWS Client Configuration used by the AWS service client in the Node. If given the node will load the
     # provided configuration when initializing the client.
     aws_client_configuration:

--- a/cloudwatch_logger/include/cloudwatch_logger/log_node_param_helper.h
+++ b/cloudwatch_logger/include/cloudwatch_logger/log_node_param_helper.h
@@ -50,6 +50,7 @@ constexpr char kNodeParamStorageDirectory[] = "storage_directory";
 constexpr char kNodeParamFileExtension[] = "file_extension";
 constexpr char kNodeParamMaximumFileSize[] = "maximum_file_size";
 constexpr char kNodeParamStorageLimit[] = "storage_limit";
+constexpr char kNodeParamDeleteStaleData[] = "delete_stale_data";
 
 constexpr char kNodeLogGroupNameDefaultValue[] = "ros_log_group";
 constexpr char kNodeLogStreamNameDefaultValue[] = "ros_log_stream";
@@ -214,6 +215,22 @@ void ReadOption(
   const std::string & option_key,
   const size_t & default_value,
   size_t & option_value);
+
+/**
+ * Fetch a single size_t option
+ *
+ * @param parameter_reader to retrieve the parameters from
+ * @param option_key the parameter key to read
+ * @param default_value a default value if the parameter doesn't exist or is unreadble
+ * @param option_value the size_t value for this option
+ * @return an error code that indicates whether the parameter was read successfully or not,
+ * as returned by \p parameter_reader
+ */
+void ReadOption(
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
+  const std::string & option_key,
+  const bool & default_value,
+  bool & option_value);
 
 }  // namespace Utils
 }  // namespace CloudWatchLogs

--- a/cloudwatch_logger/src/log_node_param_helper.cpp
+++ b/cloudwatch_logger/src/log_node_param_helper.cpp
@@ -309,6 +309,12 @@ void ReadFileManagerStrategyOptions(
     kNodeParamStorageLimit,
     Aws::FileManagement::kDefaultFileManagerStrategyOptions.storage_limit_in_kb,
     file_manager_strategy_options.storage_limit_in_kb);
+
+  ReadOption(
+    parameter_reader,
+    kNodeParamDeleteStaleData,
+    Aws::FileManagement::kDefaultFileManagerStrategyOptions.delete_stale_data,
+    file_manager_strategy_options.delete_stale_data);
 }
 
 void ReadOption(
@@ -350,6 +356,29 @@ void ReadOption(
       break;
     case Aws::AwsError::AWS_ERR_OK:
       option_value = static_cast<size_t>(return_value);
+      AWS_LOGSTREAM_INFO(__func__, option_key << " is set to: " << option_value);
+      break;
+    default:
+      option_value = default_value;
+      AWS_LOGSTREAM_ERROR(__func__,
+                          "Error " << ret << " retrieving option " << option_key << ", setting to default value: " << default_value);
+  }
+}
+
+void ReadOption(
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
+  const std::string & option_key,
+  const bool & default_value,
+  bool & option_value)
+{
+  Aws::AwsError ret = parameter_reader->ReadParam(ParameterPath(option_key), option_value);
+  switch (ret) {
+    case Aws::AwsError::AWS_ERR_NOT_FOUND:
+      option_value = default_value;
+      AWS_LOGSTREAM_INFO(__func__,
+                         option_key << " parameter not found, setting to default value: " << default_value);
+      break;
+    case Aws::AwsError::AWS_ERR_OK:
       AWS_LOGSTREAM_INFO(__func__, option_key << " is set to: " << option_value);
       break;
     default:

--- a/cloudwatch_logger/test/log_node_param_helper_test.cpp
+++ b/cloudwatch_logger/test/log_node_param_helper_test.cpp
@@ -283,6 +283,86 @@ TEST_F(LogNodeParamHelperFixture, TestReadIgnoreNodesSet)
   EXPECT_EQ(AwsError::AWS_ERR_OK, ReadIgnoreNodesSet(param_reader_, param));
   EXPECT_EQ(1u, param.count("String1"));
 }
+/**
+ * FileManagerStrategyOptions options defined with delete_stale_data set to true.
+ * First ReadParam call fails, therefore we expect options_.delete_stale_data set true->false.
+ * Second ReadParam call suceeds, therefore we expect options_.delete_stale_data set false->true.
+ * Third ReadParam call not found, therefore we expect options_.delete_stale_data set true->false.
+ */
+TEST_F(LogNodeParamHelperFixture, Test_Delete_Stale_Data_True)
+{
+  {
+    InSequence read_param_seq;
+
+    EXPECT_CALL(*param_reader_, ReadParam(Eq(ParameterPath(kNodeParamDeleteStaleData)), A<bool &>()))
+    .WillOnce(Return(AwsError::AWS_ERR_FAILURE));
+
+    EXPECT_CALL(*param_reader_, ReadParam(Eq(ParameterPath(kNodeParamDeleteStaleData)), A<bool &>()))
+    .WillOnce(
+      DoAll(SetArgReferee<1>(true), Return(AwsError::AWS_ERR_OK))
+    );
+
+    EXPECT_CALL(*param_reader_, ReadParam(Eq(ParameterPath(kNodeParamDeleteStaleData)), A<bool &>()))
+    .WillOnce(Return(AwsError::AWS_ERR_NOT_FOUND));
+  }
+
+  Aws::FileManagement::FileManagerStrategyOptions options_{"test", "log_tests/", ".log", 1024*1024, 1024*1024, true};
+  ASSERT_TRUE(options_.delete_stale_data);
+
+  ReadOption(param_reader_, kNodeParamDeleteStaleData, Aws::FileManagement::kDefaultFileManagerStrategyOptions.delete_stale_data, options_.delete_stale_data);
+  ASSERT_FALSE(options_.delete_stale_data);
+
+  ReadOption(param_reader_, kNodeParamDeleteStaleData, Aws::FileManagement::kDefaultFileManagerStrategyOptions.delete_stale_data, options_.delete_stale_data);
+  ASSERT_TRUE(options_.delete_stale_data);
+
+  ReadOption(param_reader_, kNodeParamDeleteStaleData, Aws::FileManagement::kDefaultFileManagerStrategyOptions.delete_stale_data, options_.delete_stale_data);
+  ASSERT_FALSE(options_.delete_stale_data);
+}
+/**
+ * FileManagerStrategyOptions options defined with delete_stale_data not defined.
+ * We expect that when delete_stale_data is not defined that it will default to false.
+ * First ReadParam call suceeds, therefore we expect options_.delete_stale_data set false->true.
+ * Second ReadParam call fails, therefore we expect options_.delete_stale_data set true->false.
+ * Third ReadParam call suceeds, therefore we expect options_.delete_stale_data set false->true.
+ * Forth ReadParam call not found, therefore we expect options_.delete_stale_data set true->false.
+ */
+TEST_F(LogNodeParamHelperFixture, Test_Delete_Stale_Data_Not_Defined)
+{
+  {
+    InSequence read_param_seq;
+
+    EXPECT_CALL(*param_reader_, ReadParam(Eq(ParameterPath(kNodeParamDeleteStaleData)), A<bool &>()))
+    .WillOnce(
+      DoAll(SetArgReferee<1>(true), Return(AwsError::AWS_ERR_OK))
+    );
+
+    EXPECT_CALL(*param_reader_, ReadParam(Eq(ParameterPath(kNodeParamDeleteStaleData)), A<bool &>()))
+    .WillOnce(Return(AwsError::AWS_ERR_FAILURE));
+
+    EXPECT_CALL(*param_reader_, ReadParam(Eq(ParameterPath(kNodeParamDeleteStaleData)), A<bool &>()))
+    .WillOnce(
+      DoAll(SetArgReferee<1>(true), Return(AwsError::AWS_ERR_OK))
+    );
+
+    EXPECT_CALL(*param_reader_, ReadParam(Eq(ParameterPath(kNodeParamDeleteStaleData)), A<bool &>()))
+    .WillOnce(Return(AwsError::AWS_ERR_NOT_FOUND));
+  }
+
+  Aws::FileManagement::FileManagerStrategyOptions options_{"test", "log_tests/", ".log", 1024*1024, 1024*1024};
+  ASSERT_FALSE(options_.delete_stale_data);
+
+  ReadOption(param_reader_, kNodeParamDeleteStaleData, Aws::FileManagement::kDefaultFileManagerStrategyOptions.delete_stale_data, options_.delete_stale_data);
+  ASSERT_TRUE(options_.delete_stale_data);
+
+  ReadOption(param_reader_, kNodeParamDeleteStaleData, Aws::FileManagement::kDefaultFileManagerStrategyOptions.delete_stale_data, options_.delete_stale_data);
+  ASSERT_FALSE(options_.delete_stale_data);
+
+  ReadOption(param_reader_, kNodeParamDeleteStaleData, Aws::FileManagement::kDefaultFileManagerStrategyOptions.delete_stale_data, options_.delete_stale_data);
+  ASSERT_TRUE(options_.delete_stale_data);
+
+  ReadOption(param_reader_, kNodeParamDeleteStaleData, Aws::FileManagement::kDefaultFileManagerStrategyOptions.delete_stale_data, options_.delete_stale_data);
+  ASSERT_FALSE(options_.delete_stale_data);
+}
 
 int main(int argc, char ** argv)
 {


### PR DESCRIPTION
ROS2 version of cloudwatchlogs-ros1 PR:
[Add option for FileManagerStrategy delete stale data #64](https://github.com/aws-robotics/cloudwatchlogs-ros1/pull/64)

[AWS PutLogEvents](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html) will not upload a batch log if the logs in the batch are older than 14 days. Therefore we will allow the user to specify an option in FileManagerStrategy to automatically delete 14 day old logs from the batch.

This PR will expose the delete_stale_data option to the user.

PR to add logic and testing for the option has been opened in cloudwatch-common repo:
[Allow user to automatically delete CloudWatch logs in batch that are > 14 days old #56](https://github.com/aws-robotics/cloudwatch-common/pull/56)

Signed-off-by: Jesse Ikawa <jikawa@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
